### PR TITLE
Provide adhoc query params

### DIFF
--- a/src/commands/call_command.rs
+++ b/src/commands/call_command.rs
@@ -36,7 +36,13 @@ impl CallServiceEndpointCommand {
             }
 
             for endpoint in &service.endpoints {
-                let mut endpoint_command = Command::new(endpoint.name.clone());
+                let mut endpoint_command = Command::new(endpoint.name.clone())
+                    .arg(
+                        Arg::new("query_parameters")
+                            .help("Set a query parameter for the request in the format `name=value`")
+                            .required(false)
+                            .action(ArgAction::Append)
+                    );
 
                 let templated_params = get_path_template_params(&endpoint.path_template);
                 for templated_param in templated_params {


### PR DESCRIPTION
Can now provide adhoc query-parameters that aren't included in the template

Does create smol issue where giving a malformed query-parameter argument will cause the application to panic - but ignoring that for this PR and will raise a bug issue